### PR TITLE
Inline metadata export and stabilize resume key

### DIFF
--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { type Job, resume } from "./data";
 
-const metadata: Metadata = {
+export const metadata: Metadata = {
   title: `${resume.name} — Resume`,
   description: resume.title,
 };
@@ -40,8 +40,8 @@ const ResumePage = () => (
 
     <Section title="Experience">
       <ol role="list" className="flex flex-col gap-6">
-        {resume.experience.map((job, i) => (
-          <li key={`${job.company}-${i}`}>
+        {resume.experience.map((job) => (
+          <li key={`${job.company}-${job.dates}`}>
             <JobEntry job={job} />
           </li>
         ))}
@@ -190,5 +190,4 @@ const JobEntry = ({ job }: { job: Job }) => (
   </article>
 );
 
-export { metadata };
 export default ResumePage;


### PR DESCRIPTION
## Summary
- Switched `app/resume/page.tsx` metadata to `export const metadata = …` so static analysis (and Next.js conventions) detect it.
- Replaced `${job.company}-${i}` with `${job.company}-${job.dates}` as the experience-list React key — drops the array index for a stable composite.

## Test plan
- [ ] `pnpm tsc --noEmit` passes (verified locally).
- [ ] `npx -y react-doctor@latest .` score ≥ 98 (verified locally: 97 → 98).
- [ ] `/resume` renders identically and the page `<title>` is still "Pedro Afonso Pedrosa Filho — Resume".