### PR TITLE
Add OSS and uses pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -33,8 +34,69 @@ const metadata: Metadata = {
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => (
   <html lang="en" suppressHydrationWarning className={ibmPlexMono.variable}>
-    <body className="antialiased overscroll-none min-h-dvh box-border text-primary-foreground bg-primary font-mono">
+    <body className="flex min-h-dvh flex-col box-border bg-primary font-mono text-primary-foreground antialiased overscroll-none">
       {children}
+      <nav aria-label="Primary" className="w-full bg-primary px-4 py-4">
+        <ul
+          role="list"
+          className="mx-auto flex max-w-2xl flex-wrap justify-center gap-x-2 gap-y-1 text-base sm:text-sm"
+        >
+          <li>
+            <a
+              href="https://github.com/pedroapfilho"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg px-2 py-2 font-normal no-underline text-inherit hover:bg-primary-foreground hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2"
+            >
+              Code
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://x.com/pedroapfilho"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg px-2 py-2 font-normal no-underline text-inherit hover:bg-primary-foreground hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2"
+            >
+              X
+            </a>
+          </li>
+          <li>
+            <Link
+              href="/resume"
+              className="rounded-lg px-2 py-2 font-normal no-underline text-inherit hover:bg-primary-foreground hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2"
+            >
+              Resume
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/oss"
+              className="rounded-lg px-2 py-2 font-normal no-underline text-inherit hover:bg-primary-foreground hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2"
+            >
+              OSS
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/uses"
+              className="rounded-lg px-2 py-2 font-normal no-underline text-inherit hover:bg-primary-foreground hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2"
+            >
+              /uses
+            </Link>
+          </li>
+          <li>
+            <a
+              href="https://youtube.com/c/ohmyfunction"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg px-2 py-2 font-normal no-underline text-inherit hover:bg-primary-foreground hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2"
+            >
+              Youtube
+            </a>
+          </li>
+        </ul>
+      </nav>
     </body>
   </html>
 );

--- a/app/oss/page.tsx
+++ b/app/oss/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "OSS — Pedro Filho",
+  description: "Open-source projects created by Pedro Filho.",
+};
+
+const ossProjects = [
+  {
+    name: "usebutr",
+    description:
+      "Multi-chain wallet management for React across EVM, Solana, Sui, and Bitcoin.",
+    href: "https://github.com/pedroapfilho/usebutr",
+  },
+  {
+    name: "dashfoo",
+    description:
+      "Headless React docking layout primitives for tiled, resizable, tabbed regions.",
+    href: "https://github.com/pedroapfilho/dashfoo",
+  },
+  {
+    name: "astro-theme-awesomeness",
+    description: "Theme made with Astro.",
+    href: "https://github.com/pedroapfilho/astro-theme-awesomeness",
+  },
+  {
+    name: "oxlint-config-awesomeness",
+    description:
+      "Opinionated Oxlint config for full-stack TypeScript monorepos.",
+    href: "https://github.com/pedroapfilho/oxlint-config-awesomeness",
+  },
+  {
+    name: "acme-monorepo",
+    description:
+      "Fork-ready monorepo template for apps, shared packages, tooling, and configuration.",
+    href: "https://github.com/pedroapfilho/acme-monorepo",
+  },
+  {
+    name: "acme-package",
+    description:
+      "Fork-ready monorepo template for published TypeScript libraries.",
+    href: "https://github.com/pedroapfilho/acme-package",
+  },
+];
+
+const OssPage = () => (
+  <main className="isolate flex flex-1 flex-col">
+    <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col gap-10 px-6 pt-14 pb-12 sm:px-12 sm:pt-16">
+      <header className="flex flex-col gap-3">
+        <h1 className="text-3xl font-medium tracking-tight text-balance">
+          OSS
+        </h1>
+        <p className="max-w-[64ch] text-base text-pretty sm:text-sm">
+          Open-source libraries, themes, and package experiments I have created.
+        </p>
+      </header>
+
+      <ul role="list" className="border-t border-primary-foreground/10">
+        {ossProjects.map((pkg) => (
+          <li
+            key={pkg.name}
+            className="border-b border-primary-foreground/10"
+          >
+            <a
+              href={pkg.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex items-start justify-between gap-4 py-4 no-underline focus-visible:outline-2 focus-visible:outline-offset-4"
+            >
+              <div className="flex min-w-0 flex-col gap-1">
+                <div className="font-normal underline decoration-primary-foreground/30 underline-offset-4 group-hover:decoration-primary-foreground">
+                  {pkg.name}
+                </div>
+                <p className="text-base text-primary-foreground/70 text-pretty sm:text-sm">
+                  {pkg.description}
+                </p>
+              </div>
+              <span
+                aria-hidden="true"
+                className="shrink-0 text-primary-foreground/50 group-hover:text-primary-foreground"
+              >
+                ↗
+              </span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </main>
+);
+
+export default OssPage;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,88 +1,38 @@
 import Image from "next/image";
-import Link from "next/link";
 import profileImage from "./profile.jpg";
 
 const Home = () => (
-  <main className="flex flex-col items-center justify-center relative min-h-dvh gap-8 px-4 py-8">
-    <div className="rounded-lg overflow-hidden m-4">
-      <Image
-        width={128}
-        height={128}
-        src={profileImage}
-        alt="Profile Image"
-        priority
-        fetchPriority="high"
-        placeholder="blur"
-      />
+  <main className="isolate flex flex-1 flex-col">
+    <div className="flex flex-1 flex-col items-center justify-center gap-8 px-4 py-8">
+      <div className="m-4 overflow-hidden rounded-lg">
+        <Image
+          width={128}
+          height={128}
+          src={profileImage}
+          alt="Profile Image"
+          priority
+          fetchPriority="high"
+          placeholder="blur"
+        />
+      </div>
+
+      <div className="flex flex-col gap-2 text-center">
+        <h1 className="text-2xl tracking-tight text-balance">
+          <span className="font-semibold">gm</span>, I&apos;m Pedro.
+        </h1>
+
+        <h2 className="text-base">
+          I like to write code <i>sometimes</i>.
+        </h2>
+      </div>
+
+      <div className="max-w-xl text-center">
+        <p className="text-base text-pretty sm:text-sm">
+          Usually I work on the crypto space, as a product engineer, but you can
+          find me working on other projects as well, <i>just for fun</i>.
+        </p>
+      </div>
     </div>
-
-    <div className="flex flex-col gap-2 text-center">
-      <h1 className="text-2xl">
-        <b>gm</b> 👋, I&apos;m <b>Pedro</b>.
-      </h1>
-
-      <h2 className="text-base">
-        I like to write code <i>sometimes</i>.
-      </h2>
-    </div>
-
-    <div className="text-center max-w-xl">
-      <p className="text-sm">
-        Usually I work on the crypto space, as a product engineer, but you can
-        find me working on other projects as well, <i>just for fun</i>.
-      </p>
-    </div>
-
-    <nav className="w-full absolute inset-x-0 bottom-0">
-      <ul className="flex flex-wrap justify-center gap-3 py-4">
-        <li className="inline-block">
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://github.com/pedroapfilho"
-            className="block p-2 font-normal no-underline text-inherit rounded-lg transition-all duration-200 hover:text-primary hover:bg-primary-foreground"
-          >
-            Code
-          </a>
-        </li>
-        <li className="inline-block">
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://x.com/pedroapfilho"
-            className="block p-2 font-normal no-underline text-inherit rounded-lg transition-all duration-200 hover:text-primary hover:bg-primary-foreground"
-          >
-            X
-          </a>
-        </li>
-        <li className="inline-block">
-          <Link
-            href="/resume"
-            className="block p-2 font-normal no-underline text-inherit rounded-lg transition-all duration-200 hover:text-primary hover:bg-primary-foreground"
-          >
-            Resume
-          </Link>
-        </li>
-        <li className="inline-block">
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://youtube.com/c/ohmyfunction"
-            className="block p-2 font-normal no-underline text-inherit rounded-lg transition-all duration-200 hover:text-primary hover:bg-primary-foreground"
-          >
-            Youtube
-          </a>
-        </li>
-        <li className="inline-block">
-          <a
-            href="mailto:pedro@filho.me"
-            className="block p-2 font-normal no-underline text-inherit rounded-lg transition-all duration-200 hover:text-primary hover:bg-primary-foreground"
-          >
-            Email
-          </a>
-        </li>
-      </ul>
-    </nav>
   </main>
 );
 

--- a/app/uses/page.tsx
+++ b/app/uses/page.tsx
@@ -1,0 +1,268 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "/uses — Pedro Filho",
+  description:
+    "Hardware and local development software used by Pedro Filho.",
+};
+
+const useGroups = [
+  {
+    title: "Hardware",
+    sections: [
+      {
+        title: "Computer",
+        items: [
+          {
+            name: "Apple MacBook Pro with M5 Max, 48 GB memory, 2 TB SSD",
+            href: "https://www.apple.com/macbook-pro/",
+          },
+        ],
+      },
+      {
+        title: "Displays",
+        items: [
+          {
+            name: "Dell 27 4K USB-C Hub Monitor - P2723QE",
+            href: "https://www.dell.com/en-us/shop/dell-27-4k-usb-c-hub-monitor-p2723qe/apd/210-bdlk/monitors-monitor-accessories",
+          },
+          {
+            name: "Dell Pro 27 Plus 4K USB-C Hub Monitor - P2725QE",
+            href: "https://www.dell.com/support/product-details/en-us/product/p2725qe-monitor/resources/regulatory",
+          },
+        ],
+      },
+      {
+        title: "Docking",
+        items: [
+          {
+            name: "CalDigit Thunderbolt 4 Pro Dock",
+            href: "https://www.apple.com/shop/product/hrjk2zm/a/caldigit-thunderbolt-4-pro-dock",
+          },
+          {
+            name: "CalDigit Element Hub",
+            href: "https://www.caldigit.com/thunderbolt-4-element-hub/",
+          },
+        ],
+      },
+      {
+        title: "Input",
+        items: [
+          {
+            name: "Kinesis Advantage360 Professional",
+            href: "https://kinesis-ergo.com/shop/adv360pro/",
+          },
+          {
+            name: "Logitech MX Master 4",
+            href: "https://www.logitech.com/en-us/shop/p/mx-master-4",
+          },
+          {
+            name: "Elgato Stream Deck",
+            href: "https://www.elgato.com/us/en/s/welcome-to-stream-deck",
+          },
+        ],
+      },
+      {
+        title: "Ergonomics",
+        items: [
+          {
+            name: "DeltaHub Carpio 2.0",
+            href: "https://deltahub.io/products/carpio-ergonomic-wrist-rest",
+          },
+          {
+            name: "Herman Miller Aeron Chair",
+            href: "https://www.hermanmiller.com/products/seating/office-chairs/aeron-chair/",
+          },
+        ],
+      },
+      {
+        title: "Audio",
+        items: [
+          {
+            name: "Electro-Voice RE20",
+            href: "https://products.electrovoice.com/na/en/re20",
+          },
+          {
+            name: "Rode PSA1 Studio Arm",
+            href: "https://edge.rode.com/pdf/page/202/modules/8/psa1_product_manual.pdf",
+          },
+          {
+            name: "Solid State Logic SSL 2+",
+            href: "https://solidstatelogic.com/products/ssl-2-plus-mkii",
+          },
+          {
+            name: "Edifier R990BT",
+            href: "https://www.edifier.com/global/p/bookshelf-speakers/r990bt",
+          },
+          {
+            name: "Audio-Technica ATH-M50x",
+            href: "https://www.audio-technica.com/en-us/ath-m50x",
+          },
+        ],
+      },
+      {
+        title: "Video",
+        items: [
+          {
+            name: "Sony Alpha 7 IV",
+            href: "https://electronics.sony.com/imaging/interchangeable-lens-cameras/full-frame/p/ilce7m4-b",
+          },
+          {
+            name: "Sony FE 35mm F1.4 GM",
+            href: "https://electronics.sony.com/imaging/lenses/full-frame-e-mount/p/sel35f14gm",
+          },
+          {
+            name: "Opal C1",
+            href: "https://opalcamera.com/",
+          },
+        ],
+      },
+      {
+        title: "Lighting",
+        items: [
+          {
+            name: "Logitech Litra Glow",
+            href: "https://www.logitech.com/en-us/shop/p/litra-glow.946-000001",
+          },
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          {
+            name: "Yubico YubiKey",
+            href: "https://www.yubico.com/products/yubikey-5-overview/",
+          },
+        ],
+      },
+      {
+        title: "3D Printing",
+        items: [
+          {
+            name: "Original Prusa MK4",
+            href: "https://help.prusa3d.com/product/mk4",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: "Development Software",
+    sections: [
+      {
+        title: "Editor",
+        items: [
+          {
+            name: "Zed",
+            href: "https://zed.dev/",
+          },
+          {
+            name: "Neovim",
+            href: "https://neovim.io/",
+          },
+        ],
+      },
+      {
+        title: "Terminal",
+        items: [
+          {
+            name: "Ghostty",
+            href: "https://ghostty.org/",
+          },
+          {
+            name: "cmux",
+            href: "https://cmux.com/",
+          },
+        ],
+      },
+      {
+        title: "Agent Orchestration",
+        items: [
+          {
+            name: "Conductor",
+            href: "https://conductor.build/",
+          },
+        ],
+      },
+      {
+        title: "Containers",
+        items: [
+          {
+            name: "OrbStack",
+            href: "https://orbstack.dev/",
+          },
+        ],
+      },
+      {
+        title: "Package Management",
+        items: [
+          {
+            name: "fnm",
+            href: "https://github.com/Schniz/fnm",
+          },
+        ],
+      },
+      {
+        title: "Browser",
+        items: [
+          {
+            name: "Helium",
+            href: "https://helium.computer/",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const UsesPage = () => (
+  <main className="isolate flex flex-1 flex-col">
+    <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col gap-10 px-6 pt-14 pb-12 sm:px-12 sm:pt-16">
+      <header className="flex flex-col gap-3">
+        <h1 className="text-3xl font-medium tracking-tight text-balance">
+          /uses
+        </h1>
+        <p className="max-w-[64ch] text-base text-pretty sm:text-sm">
+          Hardware connected to my computer and development software I use
+          locally.
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-10">
+        {useGroups.map((group) => (
+          <section key={group.title} className="flex flex-col gap-4">
+            <h2 className="text-base font-medium">{group.title}</h2>
+            <dl className="border-t border-primary-foreground/10">
+              {group.sections.map((section) => (
+                <div
+                  key={section.title}
+                  className="grid gap-2 border-b border-primary-foreground/10 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6"
+                >
+                  <dt className="font-medium">{section.title}</dt>
+                  <dd>
+                    <ul role="list" className="flex flex-col gap-1">
+                      {section.items.map((item) => (
+                        <li key={item.href} className="text-base sm:text-sm">
+                          <a
+                            href={item.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline decoration-primary-foreground/30 underline-offset-4 hover:decoration-primary-foreground focus-visible:outline-2 focus-visible:outline-offset-4"
+                          >
+                            {item.name}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+        ))}
+      </div>
+    </div>
+  </main>
+);
+
+export default UsesPage;

--- a/app/uses/page.tsx
+++ b/app/uses/page.tsx
@@ -28,7 +28,7 @@ const useGroups = [
           },
           {
             name: "Dell Pro 27 Plus 4K USB-C Hub Monitor - P2725QE",
-            href: "https://www.dell.com/support/product-details/en-us/product/p2725qe-monitor/resources/regulatory",
+            href: "https://www.dell.com/en-us/shop/dell-pro-27-plus-4k-usb-c-hub-monitor-p2725qe/apd/210-brjb/monitors-monitor-accessories",
           },
         ],
       },
@@ -84,7 +84,7 @@ const useGroups = [
           },
           {
             name: "Rode PSA1 Studio Arm",
-            href: "https://edge.rode.com/pdf/page/202/modules/8/psa1_product_manual.pdf",
+            href: "https://rode.com/en-us/products/psa1",
           },
           {
             name: "Solid State Logic SSL 2+",


### PR DESCRIPTION
Adds a shared bottom nav in the root layout and removes the homepage email link. Adds an /oss page with linked open-source projects and descriptions. Adds a /uses page with linked hardware and local development software. Updates the homepage copy/layout to work with the shared nav.